### PR TITLE
ビルドオプションを変更

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ before_install:
 
 script:
     - "script/bootstrap.sh"
-    - "./configure && make check"
+    - "./configure --enable-debug && make check"
     - "for pathfile in `ls src/*.c`; do gcov $pathfile; done"
 
 after_success:

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,10 +1,16 @@
 # GLOBAL CFLAGS
-AM_CFLAGS   = -coverage -O2 -Wall 
-AM_CPPFLAGS = -DLOCALEDIR='"$(localedir)"' -DPDIR_DEBUG
-AM_CXXFLAGS = $(CFLAGS)
+AM_CFLAGS   = 
+AM_CXXFLAGS = 
 
 bin_PROGRAMS = pdir
 pdir_SOURCES = src/main.c src/error.c src/list.c
+
+pdir_CFLAGS = -DLOCALEDIR='"$(localedir)"'
+if DEBUG
+pdir_CFLAGS += -DPDIR_DEBUG -O0 -g3 -coverage -Wall
+else
+pdir_CFLAGS += -O2
+endif
 
 man_MANS = man/pdir.1
 EXTRA_DIST = config.rpath  docs mano

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pDir
 [![Build Status](https://travis-ci.org/LeavaTail/pDir.svg?branch=master)](https://travis-ci.org/LeavaTail/pHex)
-[![codecov](https://codecov.io/gh/LeavaTail/pHex/branch/master/graph/badge.svg)](https://codecov.io/gh/LeavaTail/pHex)
+[![codecov](https://codecov.io/gh/LeavaTail/pDir/branch/master/graph/badge.svg)](https://codecov.io/gh/LeavaTail/pDir)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/d2ed5007af074c9a815b468551e137fa)](https://app.codacy.com/app/LeavaTail/pDir?utm_source=github.com&utm_medium=referral&utm_content=LeavaTail/pDir&utm_campaign=Badge_Grade_Dashboard)
 
 `pdir`(Print DIRectory) list directory contents that referenced `ls`(GNU Core Utilitied).

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,19 @@ AC_CONFIG_HEADERS([config.h])
 AC_USE_SYSTEM_EXTENSIONS
 
 # Checks for programs.
-: ${CFLAGS=""}
+AC_ARG_ENABLE(debug,
+AS_HELP_STRING([--enable-debug],
+               [enable debugging, default: no]),
+[case "${enableval}" in
+             yes) debug=true ;;
+             no)  debug=false ;;
+             *)   AC_MSG_ERROR([bad value ${enableval} for --enable-debug]) ;;
+esac],
+[debug=false])
+
+AM_CONDITIONAL(DEBUG, test x"$debug" = x"true")
+
+CFLAGS=" "
 AC_PROG_CC
 
 # Checks for libraries.

--- a/src/main.c
+++ b/src/main.c
@@ -16,6 +16,7 @@
 #include <time.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <locale.h>
 #include "pdir.h"
 #include "gettext.h"
 #include "error.h"


### PR DESCRIPTION
開発用とリリース用でビルドオプションを使い分けた

# 既存の問題点
いかなる場合においてもビルド時のオプションが、`-coverage -O2 -Wall` であること

# 修正点
  * `configure`時に`--enable-debug`オプションを指定できるようにし、開発時はこっちを指定
  * 上記の変更に伴って、ドキュメントの整備